### PR TITLE
Bug/duplicate output

### DIFF
--- a/genpipes/compose.py
+++ b/genpipes/compose.py
@@ -20,9 +20,10 @@ class Pipeline(object):
 
     def __repr__(self) -> str:
         """Implementation of repr to show tasks composing the current pipeline"""
+        names = []
         for index, task in enumerate(self.steps):
-            self.names.append(f"{index+1}- {task[0]}")
-        tasks = "\n".join(self.names)
+            names.append(f"{index+1}- {task[0]}")
+        tasks = "\n".join(names)
         rpr = f"""---- Start ----
 {tasks}
 ---- End ----


### PR DESCRIPTION
Changes the Pipeline.__repr__() method to use a local variable instead of the global self.names to avoid duplicate output on multiple calls

Fixes #8 